### PR TITLE
Implement WebsocketCommandMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ## 1.2.0 - 20??-??-??
 
-- Add a `WebsocketCommandMiddleware` that allows for the manipulation of the ClientPayload and possible short circuiting of other middlewares.
 - Add a `WebsocketMulticaster` that will allow for multicasting to a pool of clients without the need to ask for the Websocket directly.
 - Add a `WebsocketBroadcaster` that will allow for broadcasting to all clients without the need to ask for the Websocket directly.
 - Implement better logging within the `CommandPoweredWebsocket`.
+
+### Added
+
+- Added a `WebsocketCommandMiddleware` that allows for the manipulation of the ClientPayload and possible short circuiting of other middlewares.
+- Added a `MiddlewareChain` enum that explicitly controls how remaining middleware will be invoked; currently you can continue execution, 
+skip remaining middleware and execute command, or short circuit remaining middleware and DO NOT execute the command.
+- Added a `MiddlewareCollection` data structure that stores the global and command specific middleware.
+- Adds new methods on to the `CommandPoweredWebsocket` to facilitate adding global middleware 
 
 ## 1.1.0 - 2019-9-15
 

--- a/src/Enum/MiddlewareChain.php
+++ b/src/Enum/MiddlewareChain.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Enum;
+
+use Cspray\Yape\Enum;
+
+/**
+ * An object that represents how the CommandPoweredWebsocket should execute WebsocketCommandMiddleware.
+ *
+ * @package Cspray\WebsocketCommand\Enum
+ */
+final class MiddlewareChain implements Enum {
+
+    private static $container = [];
+
+    private $enumConstName;
+    private $value;
+
+    private function __construct(string $enumConstName, string $value) {
+        $this->enumConstName = $enumConstName;
+        $this->value = $value;
+    }
+
+    private static function getSingleton(...$constructorArgs) {
+        $name = $constructorArgs[0];
+        if (!isset(self::$container[$name])) {
+            self::$container[$name] = new self(...$constructorArgs);
+        }
+
+        return self::$container[$name];
+    }
+
+    /**
+     * Represents that the next WebsocketCommandMiddleware in the chain, or the WebsocketCommand itself, should be
+     * executed.
+     *
+     * @return MiddlewareChain
+     */
+    public static function Continue() : MiddlewareChain {
+        return self::getSingleton('Continue', 'Continue');
+    }
+
+    /**
+     * Represents that all of the remaining WebsocketCommandMiddleware can be skipped and to execute the WebsocketCommand
+     * next.
+     *
+     * @return MiddlewareChain
+     */
+    public static function Skip() : MiddlewareChain {
+        return self::getSingleton('Skip', 'Skip');
+    }
+
+    /**
+     * Represents that the WebsocketCommandMiddleware has responded to the Client, if necessary, and that no additional
+     * middleware nor the WebsocketCommand itself shall be executed.
+     *
+     * @return MiddlewareChain
+     */
+    public static function ShortCircuit() : MiddlewareChain {
+        return self::getSingleton('ShortCircuit', 'ShortCircuit');
+    }
+
+    public function getValue() : string {
+        return $this->value;
+    }
+
+    public function equals(MiddlewareChain $middlewareChain) : bool {
+        return $this === $middlewareChain;
+    }
+
+    public function toString() : string {
+        return get_class($this) . '@' . $this->enumConstName;
+    }
+
+}

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Exception;
+
+use RuntimeException;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Exception
+ * @license See LICENSE in source root
+ */
+class Exception extends RuntimeException {
+}

--- a/src/Exception/InvalidTypeException.php
+++ b/src/Exception/InvalidTypeException.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Exception;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Exception
+ * @license See LICENSE in source root
+ */
+class InvalidTypeException extends Exception {
+
+}

--- a/src/MiddlewareCollection.php
+++ b/src/MiddlewareCollection.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands
+ * @license See LICENSE in source root
+ */
+final class MiddlewareCollection {
+
+    private $collection = [
+        'global' => [],
+        'commands' => []
+    ];
+
+    /**
+     * Return a list of WebsocketCommandMiddleware that will be applied to every WebsocketCommand execution.
+     *
+     * @return WebsocketCommandMiddleware[]
+     */
+    public function getGlobalMiddlewares() : array {
+        return $this->collection['global'];
+    }
+
+    /**
+     * Return a map of WebsocketCommandMiddleware where the key is the WebsocketCommand::getName and the value is a
+     * list of WebsocketCommandMiddleware.
+     *
+     * @return array
+     */
+    public function getCommandSpecificMiddlewares() : array {
+        return $this->collection['commands'];
+    }
+
+    public function getMiddlewaresForCommand(WebsocketCommand $websocketCommand) : array {
+        $globalMiddlewares = $this->getGlobalMiddlewares();
+        $commandMiddlewares = $this->getCommandSpecificMiddlewares()[$websocketCommand->getName()] ?? [];
+
+        return array_merge($globalMiddlewares, $commandMiddlewares);
+    }
+
+    public function addGlobalMiddleware(WebsocketCommandMiddleware $middleware) : void {
+        $this->collection['global'][] = $middleware;
+    }
+
+    public function addCommandSpecificMiddleware(WebsocketCommand $command, WebsocketCommandMiddleware $middleware) : void {
+        $name = $command->getName();
+        if (!isset($this->collection['commands'][$name])) {
+            $this->collection['commands'][$name] = [];
+        }
+
+        $this->collection['commands'][$name][] = $middleware;
+
+    }
+
+}

--- a/src/WebsocketCommand.php
+++ b/src/WebsocketCommand.php
@@ -16,6 +16,8 @@ interface WebsocketCommand {
     /**
      * Return the name that the client must use to execute this WebsocketCommand.
      *
+     *
+     *
      * @return string
      */
     public function getName() : string;

--- a/src/WebsocketCommandMiddleware.php
+++ b/src/WebsocketCommandMiddleware.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands;
+
+use Amp\Promise;
+use Amp\Websocket\Client;
+use Cspray\WebsocketCommands\Enum\MiddlewareChain;
+
+/**
+ * A middleware that will run before a WebsocketCommand is executed and allows the ability to modify the ClientPayload,
+ * short-circuit execution of the WebsocketCommand any anything else you'd generally do in traditional middleware.
+ *
+ * @package Cspray\WebsocketCommands
+ * @license See LICENSE in source root
+ */
+interface WebsocketCommandMiddleware {
+
+    /**
+     * Handle that a Client has requested a WebsocketCommand with the given ClientPayload; you may modify the
+     * ClientPayload object.
+     *
+     * The Promise returned SHOULD resolve with a MiddlewareChain instance describing what should happen with the next
+     * WebsocketCommandMiddleware that would be executed. Generally speaking this library prefers explicitness over
+     * implicitness, however you may also resolve the Promise with null which is an implicit MiddlewareChain::Continue.
+     * Any value other than a MiddlewareChain instance or null will result in an InvalidTypeException.
+     *
+     * @param Client $client
+     * @param ClientPayload $clientPayload
+     * @return Promise<MiddlewareChain|null>
+     */
+    public function handleClient(Client $client, ClientPayload $clientPayload) : Promise;
+
+}

--- a/test/CommandPoweredWebsocketTest.php
+++ b/test/CommandPoweredWebsocketTest.php
@@ -12,6 +12,8 @@ use Amp\Success;
 use Amp\Websocket\Code;
 use Cspray\WebsocketCommands\ClientPayload;
 use Cspray\WebsocketCommands\CommandPoweredWebsocket;
+use Cspray\WebsocketCommands\Enum\MiddlewareChain;
+use Cspray\WebsocketCommands\Exception\InvalidTypeException;
 use Cspray\WebsocketCommands\HandshakeAuthenticator;
 use Cspray\WebsocketCommands\Internal\Enum\WebsocketError;
 use Cspray\WebsocketCommands\Internal\WebsocketErrorPayload;
@@ -20,6 +22,13 @@ use Cspray\WebsocketCommands\Test\Stub\StubCommandClientDisconnectObserver;
 use Cspray\WebsocketCommands\Test\Stub\StubHandshakeAuthenticator;
 use Cspray\WebsocketCommands\Test\Stub\StubReceiveClient;
 use Cspray\WebsocketCommands\Test\Stub\StubWebsocketCommand;
+use Cspray\WebsocketCommands\Test\Stub\StubWebsocketCommandMiddlewareBadResolve;
+use Cspray\WebsocketCommands\Test\Stub\StubWebsocketCommandMiddlewareExplicitContinue;
+use Cspray\WebsocketCommands\Test\Stub\StubWebsocketCommandMiddlewareImplicitContinue;
+use Cspray\WebsocketCommands\Test\Stub\StubWebsocketCommandMiddlewareShortCircuit;
+use Cspray\WebsocketCommands\Test\Stub\StubWebsocketCommandMiddlewareSkip;
+use Cspray\WebsocketCommands\Test\Support\Counter;
+use Cspray\WebsocketCommands\WebsocketCommandMiddleware;
 use League\Uri;
 use ReflectionMethod;
 use stdClass;
@@ -37,6 +46,7 @@ class CommandPoweredWebsocketTest extends AsyncTestCase {
 
     private $request;
     private $response;
+    private $counter;
 
     public function setUp() : void {
         parent::setUp();
@@ -44,6 +54,7 @@ class CommandPoweredWebsocketTest extends AsyncTestCase {
         $this->handshakeAuthenticator = $this->getMockBuilder(HandshakeAuthenticator::class)->getMock();
         $this->request = new Request($this->httpServerClient, 'GET', Uri\Http::createFromString('/'));
         $this->response = new Response();
+        $this->counter = new Counter();
     }
 
     public function getStubbedCommandPoweredWebsocket() {
@@ -123,7 +134,7 @@ class CommandPoweredWebsocketTest extends AsyncTestCase {
             ]
         ])));
 
-        $command = new StubWebsocketCommand();
+        $command = new StubWebsocketCommand($this->counter);
         $subject = $this->getStubbedCommandPoweredWebsocket();
         $subject->addCommands($command);
 
@@ -136,6 +147,185 @@ class CommandPoweredWebsocketTest extends AsyncTestCase {
         $this->assertSame($client, $command->client);
         $this->assertInstanceOf(ClientPayload::class, $actualPayload);
         $this->assertSame(42, $actualPayload->get('data.foo.bar.baz'));
+        $this->assertCount(1, $this->counter);
+    }
+
+    public function testMiddlewarePassedCorrectClientAndClientPayload() {
+        $counter = new Counter();
+        $command = new StubWebsocketCommand($counter);
+
+        $one = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+
+        $subject = $this->getStubbedCommandPoweredWebsocket();
+
+        $subject->addCommands($command);
+        $subject->addMiddlewares($one);
+
+        $client = new StubReceiveClient(1, new InMemoryStream(json_encode([
+            'command' => 'stub-websocket-command',
+            'data' => [
+                'foo' => [
+                    'bar' => [
+                        'baz' => 42
+                    ]
+                ]
+            ]
+        ])));
+
+        yield $this->executeMethod($subject, 'onConnect', $client, $this->request, $this->response);
+
+        $this->assertCount(2, $counter);
+        $this->assertSame($client, $one->client);
+        $this->assertInstanceOf(ClientPayload::class, $one->clientPayload);
+        $this->assertSame(42, $one->clientPayload->get('data.foo.bar.baz'));
+        $this->assertNull($one->commandClient);
+        $this->assertNull($one->commandClientPayload);
+    }
+
+    public function testExecuteMultipleMiddleware() {
+        $counter = new Counter();
+        $command = new StubWebsocketCommand($counter);
+
+        $one = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $two = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $three = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+
+        $subject = $this->getStubbedCommandPoweredWebsocket();
+
+        $subject->addCommands($command);
+        $subject->addMiddlewares($one, $two, $three);
+
+        $client = new StubReceiveClient(1, new InMemoryStream(json_encode([
+            'command' => 'stub-websocket-command',
+        ])));
+
+        yield $this->executeMethod($subject, 'onConnect', $client, $this->request, $this->response);
+
+        $this->assertCount(4, $counter);
+    }
+
+    public function testImplicitContinueRespected() {
+        $counter = new Counter();
+        $command = new StubWebsocketCommand($counter);
+
+        $one = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $two = new StubWebsocketCommandMiddlewareImplicitContinue($counter, $command);
+        $three = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+
+        $subject = $this->getStubbedCommandPoweredWebsocket();
+
+        $subject->addCommands($command);
+        $subject->addMiddlewares($one, $two, $three);
+
+        $client = new StubReceiveClient(1, new InMemoryStream(json_encode([
+            'command' => 'stub-websocket-command',
+        ])));
+
+        yield $this->executeMethod($subject, 'onConnect', $client, $this->request, $this->response);
+
+        $this->assertCount(4, $counter);
+    }
+
+    public function testSkipMiddlewareRespected() {
+        $counter = new Counter();
+        $command = new StubWebsocketCommand($counter);
+
+        $one = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $two = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $three = new StubWebsocketCommandMiddlewareSkip($counter, $command);
+        $four = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $five = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+
+        $subject = $this->getStubbedCommandPoweredWebsocket();
+
+        $subject->addCommands($command);
+        $subject->addMiddlewares($one, $two, $three, $four, $five);
+
+        $client = new StubReceiveClient(1, new InMemoryStream(json_encode([
+            'command' => 'stub-websocket-command',
+        ])));
+
+        yield $this->executeMethod($subject, 'onConnect', $client, $this->request, $this->response);
+
+        $this->assertCount(4, $counter);
+    }
+
+    public function testShortCircuitMiddlewareRespected() {
+        $counter = new Counter();
+        $command = new StubWebsocketCommand($counter);
+
+        $one = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $two = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $three = new StubWebsocketCommandMiddlewareShortCircuit($counter, $command);
+        $four = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $five = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+
+        $subject = $this->getStubbedCommandPoweredWebsocket();
+
+        $subject->addCommands($command);
+        $subject->addMiddlewares($one, $two, $three, $four, $five);
+
+        $client = new StubReceiveClient(1, new InMemoryStream(json_encode([
+            'command' => 'stub-websocket-command',
+        ])));
+
+        yield $this->executeMethod($subject, 'onConnect', $client, $this->request, $this->response);
+
+        $this->assertCount(3, $counter);
+        $this->assertNull($command->client);
+        $this->assertNull($command->clientPayload);
+    }
+
+    public function testGlobalAndCommandSpecificMiddlewareGetExecuted() {
+        $counter = new Counter();
+        $command = new StubWebsocketCommand($counter);
+
+        $one = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+        $two = new StubWebsocketCommandMiddlewareExplicitContinue($counter, $command);
+
+        $subject = $this->getStubbedCommandPoweredWebsocket();
+
+        $subject->addCommand($command, $two);
+        $subject->addMiddlewares($one);
+
+        $client = new StubReceiveClient(1, new InMemoryStream(json_encode([
+            'command' => 'stub-websocket-command',
+        ])));
+
+        yield $this->executeMethod($subject, 'onConnect', $client, $this->request, $this->response);
+
+        $this->assertCount(3, $counter);
+    }
+
+    public function testMiddlewareResolvesWrongTypeThrowsException() {
+        $counter = new Counter();
+        $command = new StubWebsocketCommand($counter);
+
+        $one = new StubWebsocketCommandMiddlewareBadResolve();
+
+        $subject = $this->getStubbedCommandPoweredWebsocket();
+
+        $subject->addCommand($command, $one);
+
+        $client = new StubReceiveClient(1, new InMemoryStream(json_encode([
+            'command' => 'stub-websocket-command',
+        ])));
+
+        $this->expectException(InvalidTypeException::class);
+        $msg = sprintf('The resolved Promise from a %s MUST be a %s instance or be null.', WebsocketCommandMiddleware::class, MiddlewareChain::class);
+        $this->expectExceptionMessage($msg);
+
+        yield $this->executeMethod($subject, 'onConnect', $client, $this->request, $this->response);
+    }
+
+    public function testAddCommandClientDisconnectObserver() {
+        $command = new StubCommandClientDisconnectObserver();
+
+        $subject = $this->getStubbedCommandPoweredWebsocket();
+
+        $subject->addCommand($command);
+
+        $this->assertEquals([$command], $subject->getClientDisconnectObservers());
     }
 
     public function testDisconnectObserverSeesWhenAllClientsDisconnect() {
@@ -144,7 +334,7 @@ class CommandPoweredWebsocketTest extends AsyncTestCase {
             'data' => []
         ])));
 
-        $command = new StubWebsocketCommand();
+        $command = new StubWebsocketCommand($this->counter);
         $subject = $this->getStubbedCommandPoweredWebsocket();
         $subject->addCommands($command);
 

--- a/test/MiddlewareCollectionTest.php
+++ b/test/MiddlewareCollectionTest.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Test;
+
+use Cspray\WebsocketCommands\MiddlewareCollection;
+use Cspray\WebsocketCommands\Test\Stub\StubWebsocketCommand;
+use Cspray\WebsocketCommands\Test\Support\Counter;
+use Cspray\WebsocketCommands\WebsocketCommand;
+use Cspray\WebsocketCommands\WebsocketCommandMiddleware;
+use PHPUnit\Framework\TestCase;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Test
+ * @license See LICENSE in source root
+ */
+class MiddlewareCollectionTest extends TestCase {
+
+    public function testGetGlobalMiddlewaresEmpty() {
+        $subject = new MiddlewareCollection();
+
+        $this->assertEmpty($subject->getGlobalMiddlewares());
+    }
+
+    public function testGetGlobalMiddlewaresNotEmpty() {
+        $subject = new MiddlewareCollection();
+
+        $one = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+        $two = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+        $three = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+
+        $subject->addGlobalMiddleware($one);
+        $subject->addGlobalMiddleware($two);
+        $subject->addGlobalMiddleware($three);
+
+        $this->assertSame([$one, $two, $three], $subject->getGlobalMiddlewares());
+    }
+
+    public function testGetCommandSpecificMiddlewaresEmpty() {
+        $subject = new MiddlewareCollection();
+
+        $this->assertEmpty($subject->getCommandSpecificMiddlewares());
+    }
+
+    public function testGetCommandSpecificMiddlewaresNotEmpty() {
+        $subject = new MiddlewareCollection();
+        $counter = new Counter();
+        $oneCommand = new StubWebsocketCommand($counter, 'one');
+        $twoCommand = new StubWebsocketCommand($counter, 'two');
+
+        $oneMiddleware = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+        $twoMiddleware = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+        $threeMiddleware = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+
+        $subject->addCommandSpecificMiddleware($oneCommand, $oneMiddleware);
+        $subject->addCommandSpecificMiddleware($oneCommand, $twoMiddleware);
+        $subject->addCommandSpecificMiddleware($twoCommand, $threeMiddleware);
+
+        $expected = ['one' => [$oneMiddleware, $twoMiddleware], 'two' => [$threeMiddleware]];
+        $actual = $subject->getCommandSpecificMiddlewares();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetMiddlewaresForCommandEmptyGlobalAndEmptyCommandSpecific() {
+        $subject = new MiddlewareCollection();
+        $command = new StubWebsocketCommand(new Counter());
+
+        $actual = $subject->getMiddlewaresForCommand($command);
+
+        $this->assertEmpty($actual);
+    }
+
+    public function testGetMiddlewaresForCommandNotEmptyGlobalAndEmptyCommandSpecific() {
+        $subject = new MiddlewareCollection();
+        $command = new StubWebsocketCommand(new Counter());
+
+        $middleware = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+
+        $subject->addGlobalMiddleware($middleware);
+
+        $actual = $subject->getMiddlewaresForCommand($command);
+
+        $this->assertSame([$middleware], $actual);
+    }
+
+    public function testGetMiddlewaresForCommandEmptyGlobalAndNotEmptyCommandSpecific() {
+        $subject = new MiddlewareCollection();
+        $command = new StubWebsocketCommand(new Counter());
+
+        $middleware = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+
+        $subject->addCommandSpecificMiddleware($command, $middleware);
+
+        $actual = $subject->getMiddlewaresForCommand($command);
+
+        $this->assertSame([$middleware], $actual);
+    }
+
+    public function testGetMiddlewaresForCommandNotEmptyGlobalAndNotEmptyCommandSpecific() {
+        $subject = new MiddlewareCollection();
+        $command = new StubWebsocketCommand(new Counter());
+
+        $globalMiddleware = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+        $commandMiddleware = $this->getMockBuilder(WebsocketCommandMiddleware::class)->getMock();
+
+        $subject->addGlobalMiddleware($globalMiddleware);
+        $subject->addCommandSpecificMiddleware($command, $commandMiddleware);
+
+        $actual = $subject->getMiddlewaresForCommand($command);
+
+        $this->assertSame([$globalMiddleware, $commandMiddleware], $actual);
+
+        // make sure that above operation didn't accidentally mutate the state of the collection
+        $this->assertSame([$globalMiddleware], $subject->getGlobalMiddlewares());
+        $this->assertSame(['stub-websocket-command' => [$commandMiddleware]], $subject->getCommandSpecificMiddlewares());
+    }
+
+}

--- a/test/Stub/StubWebsocketCommand.php
+++ b/test/Stub/StubWebsocketCommand.php
@@ -6,6 +6,7 @@ use Amp\Promise;
 use Amp\Success;
 use Amp\Websocket\Client;
 use Cspray\WebsocketCommands\ClientPayload;
+use Cspray\WebsocketCommands\Test\Support\Counter;
 use Cspray\WebsocketCommands\WebsocketCommand;
 use function Amp\call;
 
@@ -20,8 +21,10 @@ class StubWebsocketCommand implements WebsocketCommand {
     public $clientPayload;
 
     private $name;
+    private $counter;
 
-    public function __construct(string $name = 'stub-websocket-command') {
+    public function __construct(Counter $counter, string $name = 'stub-websocket-command') {
+        $this->counter = $counter;
         $this->name = $name;
     }
 
@@ -40,6 +43,7 @@ class StubWebsocketCommand implements WebsocketCommand {
         return call(function() use($client, $clientPayload) {
             $this->client = $client;
             $this->clientPayload = $clientPayload;
+            $this->counter->increment();
         });
     }
 

--- a/test/Stub/StubWebsocketCommandMiddlewareBadResolve.php
+++ b/test/Stub/StubWebsocketCommandMiddlewareBadResolve.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Test\Stub;
+
+use Amp\Promise;
+use Amp\Success;
+use Amp\Websocket\Client;
+use Cspray\WebsocketCommands\ClientPayload;
+use Cspray\WebsocketCommands\WebsocketCommandMiddleware;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Test\Stub
+ * @license See LICENSE in source root
+ */
+class StubWebsocketCommandMiddlewareBadResolve implements WebsocketCommandMiddleware {
+
+    /**
+     * Handle that a Client has requested a WebsocketCommand with the given ClientPayload; you may modify the
+     * ClientPayload object.
+     *
+     * The Promise returned SHOULD resolve with a MiddlewareChain instance describing what should happen with the next
+     * WebsocketCommandMiddleware that would be executed. Generally speaking this library prefers explicitness over
+     * implicitness, however you may also resolve the Promise with null which is an implicit MiddlewareChain::Continue.
+     * Any value other than a MiddlewareChain instance or null will result in an InvalidTypeException.
+     *
+     * @param Client $client
+     * @param ClientPayload $clientPayload
+     * @return Promise<MiddlewareChain|null>
+     */
+    public function handleClient(Client $client, ClientPayload $clientPayload) : Promise {
+        return new Success('not a valid resolve value');
+    }
+
+}

--- a/test/Stub/StubWebsocketCommandMiddlewareExplicitContinue.php
+++ b/test/Stub/StubWebsocketCommandMiddlewareExplicitContinue.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Test\Stub;
+
+use Amp\Promise;
+use Amp\Websocket\Client;
+use Cspray\WebsocketCommands\Enum\MiddlewareChain;
+use Cspray\WebsocketCommands\ClientPayload;
+use Cspray\WebsocketCommands\Test\Support\Counter;
+use Cspray\WebsocketCommands\WebsocketCommandMiddleware;
+use function Amp\call;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Test\Stub
+ * @license See LICENSE in source root
+ */
+class StubWebsocketCommandMiddlewareExplicitContinue implements WebsocketCommandMiddleware {
+
+    public $client;
+    public $clientPayload;
+
+    public $commandClient;
+    public $commandClientPayload;
+
+    private $counter;
+    private $command;
+
+    public function __construct(Counter $counter, StubWebsocketCommand $command) {
+        $this->counter = $counter;
+        $this->command = $command;
+    }
+
+    /**
+     * Handle that a Client has requested a WebsocketCommand with the given ClientPayload; you may modify the
+     * ClientPayload object.
+     *
+     * The Promise returned SHOULD resolve with a MiddlewareChain instance describing what should happen with the next
+     * WebsocketCommandMiddleware that would be executed. Generally speaking this library prefers explicitness over
+     * implicitness, however you may also resolve the Promise with null which is an implicit MiddlewareChain::Continue.
+     * Any value other than a MiddlewareChain instance or null will result in an InvalidTypeException.
+     *
+     * @param Client $client
+     * @param ClientPayload $clientPayload
+     * @return Promise<MiddlewareChain|null>
+     */
+    public function handleClient(Client $client, ClientPayload $clientPayload) : Promise {
+        return call(function() use($client, $clientPayload) {
+            $this->client = $client;
+            $this->clientPayload = $clientPayload;
+
+            $this->commandClient = $this->command->client;
+            $this->commandClientPayload = $this->command->clientPayload;
+
+            $this->counter->increment();
+
+            return MiddlewareChain::Continue();
+        });
+    }
+
+}

--- a/test/Stub/StubWebsocketCommandMiddlewareImplicitContinue.php
+++ b/test/Stub/StubWebsocketCommandMiddlewareImplicitContinue.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Test\Stub;
+
+use Amp\Promise;
+use Amp\Websocket\Client;
+use Cspray\WebsocketCommands\Enum\MiddlewareChain;
+use Cspray\WebsocketCommands\ClientPayload;
+use Cspray\WebsocketCommands\Test\Support\Counter;
+use Cspray\WebsocketCommands\WebsocketCommandMiddleware;
+use function Amp\call;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Test\Stub
+ * @license See LICENSE in source root
+ */
+class StubWebsocketCommandMiddlewareImplicitContinue implements WebsocketCommandMiddleware {
+
+    public $client;
+    public $clientPayload;
+
+    public $commandClient;
+    public $commandClientPayload;
+
+    private $counter;
+    private $command;
+
+    public function __construct(Counter $counter, StubWebsocketCommand $stubWebsocketCommand) {
+        $this->counter = $counter;
+        $this->command = $stubWebsocketCommand;
+    }
+
+    /**
+     * Handle that a Client has requested a WebsocketCommand with the given ClientPayload; you may modify the
+     * ClientPayload object.
+     *
+     * The Promise returned SHOULD resolve with a MiddlewareChain instance describing what should happen with the next
+     * WebsocketCommandMiddleware that would be executed. Generally speaking this library prefers explicitness over
+     * implicitness, however you may also resolve the Promise with null which is an implicit MiddlewareChain::Continue.
+     * Any value other than a MiddlewareChain instance or null will result in an InvalidTypeException.
+     *
+     * @param Client $client
+     * @param ClientPayload $clientPayload
+     * @return Promise<MiddlewareChain|null>
+     */
+    public function handleClient(Client $client, ClientPayload $clientPayload) : Promise {
+        return call(function() use($client, $clientPayload) {
+            $this->client = $client;
+            $this->clientPayload = $clientPayload;
+
+            $this->commandClient = $this->command->client;
+            $this->commandClientPayload = $this->command->clientPayload;
+
+            $this->counter->increment();
+        });
+    }
+}

--- a/test/Stub/StubWebsocketCommandMiddlewareShortCircuit.php
+++ b/test/Stub/StubWebsocketCommandMiddlewareShortCircuit.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Test\Stub;
+
+use Amp\Promise;
+use Amp\Websocket\Client;
+use Cspray\WebsocketCommands\Enum\MiddlewareChain;
+use Cspray\WebsocketCommands\ClientPayload;
+use Cspray\WebsocketCommands\Test\Support\Counter;
+use Cspray\WebsocketCommands\WebsocketCommandMiddleware;
+use function Amp\call;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Test\Stub
+ * @license See LICENSE in source root
+ */
+class StubWebsocketCommandMiddlewareShortCircuit implements WebsocketCommandMiddleware {
+
+    public $client;
+    public $clientPayload;
+
+    public $commandClient;
+    public $commandClientPayload;
+
+    private $counter;
+    private $command;
+
+    public function __construct(Counter $counter, StubWebsocketCommand $command) {
+        $this->counter = $counter;
+        $this->command = $command;
+    }
+
+    /**
+     * Handle that a Client has requested a WebsocketCommand with the given ClientPayload; you may modify the
+     * ClientPayload object.
+     *
+     * The Promise returned SHOULD resolve with a MiddlewareChain instance describing what should happen with the next
+     * WebsocketCommandMiddleware that would be executed. Generally speaking this library prefers explicitness over
+     * implicitness, however you may also resolve the Promise with null which is an implicit MiddlewareChain::Continue.
+     * Any value other than a MiddlewareChain instance or null will result in an InvalidTypeException.
+     *
+     * @param Client $client
+     * @param ClientPayload $clientPayload
+     * @return Promise<MiddlewareChain|null>
+     */
+    public function handleClient(Client $client, ClientPayload $clientPayload) : Promise {
+        return call(function() use($client, $clientPayload) {
+            $this->client = $client;
+            $this->clientPayload = $clientPayload;
+
+            $this->commandClient = $this->command->client;
+            $this->commandClientPayload = $this->command->clientPayload;
+
+            $this->counter->increment();
+
+            return MiddlewareChain::ShortCircuit();
+        });
+
+    }
+
+}

--- a/test/Stub/StubWebsocketCommandMiddlewareSkip.php
+++ b/test/Stub/StubWebsocketCommandMiddlewareSkip.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Test\Stub;
+
+use Amp\Promise;
+use Amp\Websocket\Client;
+use Cspray\WebsocketCommands\Enum\MiddlewareChain;
+use Cspray\WebsocketCommands\ClientPayload;
+use Cspray\WebsocketCommands\Test\Support\Counter;
+use Cspray\WebsocketCommands\WebsocketCommandMiddleware;
+use function Amp\call;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Test\Stub
+ * @license See LICENSE in source root
+ */
+class StubWebsocketCommandMiddlewareSkip implements WebsocketCommandMiddleware {
+
+    public $client;
+    public $clientPayload;
+
+    public $commandClient;
+    public $commandClientPayload;
+
+    private $counter;
+    private $command;
+
+    public function __construct(Counter $counter, StubWebsocketCommand $command) {
+        $this->counter = $counter;
+        $this->command = $command;
+    }
+
+    /**
+     * Handle that a Client has requested a WebsocketCommand with the given ClientPayload; you may modify the
+     * ClientPayload object.
+     *
+     * The Promise returned SHOULD resolve with a MiddlewareChain instance describing what should happen with the next
+     * WebsocketCommandMiddleware that would be executed. Generally speaking this library prefers explicitness over
+     * implicitness, however you may also resolve the Promise with null which is an implicit MiddlewareChain::Continue.
+     * Any value other than a MiddlewareChain instance or null will result in an InvalidTypeException.
+     *
+     * @param Client $client
+     * @param ClientPayload $clientPayload
+     * @return Promise<MiddlewareChain|null>
+     */
+    public function handleClient(Client $client, ClientPayload $clientPayload) : Promise {
+        return call(function() use($client, $clientPayload) {
+            $this->client = $client;
+            $this->clientPayload = $clientPayload;
+
+            $this->commandClient = $this->command->client;
+            $this->commandClientPayload = $this->command->clientPayload;
+
+            $this->counter->increment();
+
+            return MiddlewareChain::Skip();
+        });
+
+    }
+
+}

--- a/test/Support/Counter.php
+++ b/test/Support/Counter.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Cspray\WebsocketCommands\Test\Support;
+
+use Countable;
+
+/**
+ *
+ * @package Cspray\WebsocketCommands\Test\Support
+ * @license See LICENSE in source root
+ */
+final class Counter implements Countable {
+
+    private $counter = 0;
+
+    public function increment() : void {
+        $this->counter++;
+    }
+
+    /**
+     * The number of times this Counter has been incremented.
+     */
+    public function count() {
+        return $this->counter;
+    }
+
+}


### PR DESCRIPTION
- Adds a WebsocketCommandMiddleware interface that allows for the
execution of code before a WebsocketCommand is executed that allows you
to perform authorization actions, mutating the ClientPayload, or
anything else you'd like to do _before_ a WebsocketCommand is executed.
This system also allows you to resolve the middleware Promise with a
MiddlewareChain instance to determine whether the next middleware should
be executed, skip straight to the command, or short-circuit all
remaining middleware and do not execute the command.

- Adds new methods to the CommandPoweredWebsocket that allows you to
attach global middleware which will apply to all commands and you can
add command-specific middleware. If there are both global and command
specific middleware avaiable the global middleware will run first
followed by the command-specific middleware. The middleware will be
executed in the order they were added to the CommandPoweredWebsocket.