### PR TITLE
Update contact address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [websocket-commands@cspray.io]. All
+reported by contacting the project team at [conduct@cspray.io]. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -70,7 +70,7 @@ members of the project's leadership.
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
-[websocket-commands@cspray.io]: mailto:websocket-commands@cspray.io
+[conduct@cspray.io]: mailto:conduct@cspray.io
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see


### PR DESCRIPTION
Updates the contact address in the code of conduct to be consistent with the email address used for my OSS projects.